### PR TITLE
fixed: link to thread init lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(Qt5OpenGL REQUIRED)
 find_package(GoTools REQUIRED)
 find_package(GoTrivariate REQUIRED)
 find_package(OpenGL REQUIRED)
+find_package(Threads)
 
 configure_file(
   "${CMAKE_CURRENT_LIST_DIR}/src/main.h.in"
@@ -68,6 +69,7 @@ target_link_libraries(BSGUI
   ${GoTrivariate_LIBRARIES}
   ${GoTools_LIBRARIES}
   ${OPENGL_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
   )
 
 install(TARGETS BSGUI RUNTIME DESTINATION bin)


### PR DESCRIPTION
needs to link to thread init lib (pthread on linux).

you can find debian packaging for bsgui at https://github.com/akva2/packaging/tree/master/bsgui/0.1.2/debian
